### PR TITLE
FundraiseUp: Hide popup banners

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -109,14 +109,3 @@ body {
 .rt-Text {
    color: var(--light-background);
 }
-
-iframe#XBWGTSDK {
-   display: none !important;
-   visibility: hidden !important;
-   width: 0 !important;
-   height: 0 !important;
-   opacity: 0 !important;
-   pointer-events: none !important;
-   position: absolute !important;
-   overflow: hidden !important;
-}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -209,6 +209,7 @@ export const HighlightedText = ({
       <Text
          size={{ initial: "6", xs: "7", md: "8" }}
          weight="bold"
+         align="center"
          style={{ color: "white" }}
       >
          {children}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -107,6 +107,14 @@ export default async function RootLayout({
                t.parentNode.insertBefore(j,t);o.s=Date.now();o.v=5;o.h=w.location.href;o.l=[];
                for(i=0;i<8;i++)o[l[i]]=o(l[i]);w[n]=o}
                })(window,document,'script','FundraiseUp','AUAHPMKJ');
+
+               (function(){
+                  var observer = new MutationObserver(function(){
+                     var el = document.getElementById('XBWGTSDK');
+                     if(el) el.remove();
+                  });
+                  observer.observe(document.documentElement,{childList:true,subtree:true});
+               })();
             `}
          </Script>
          <body>


### PR DESCRIPTION
The `important` css worked on desktop, but not on mobile. The banners show donations to a different campaign. Let's make sure they're always hidden on all devices.